### PR TITLE
Implement an Emfatic-based view for comparing Ecore metamodels (fixes #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ bin/
 target/
 target-plain/
 *.jar
+.DS_Store
+.META-INF_MANIFEST.MF
+.polyglot.*
 
 # Metadata from Dash tool
 DEPENDENCIES*

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/.classpath
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/.project
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emf.emfatic.compare.ecore</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/META-INF/MANIFEST.MF
@@ -8,7 +8,11 @@ Require-Bundle: org.eclipse.compare;bundle-version="3.0.0",
  org.eclipse.swt;bundle-version="3.0.0",
  org.eclipse.jface;bundle-version="3.0.0",
  org.eclipse.core.runtime;bundle-version="3.0.0",
- org.eclipse.text
+ org.eclipse.text,
+ org.eclipse.emf.compare.ide.ui;bundle-version="4.4.3",
+ org.eclipse.emf.compare.rcp.ui;bundle-version="4.4.2",
+ org.eclipse.emf.compare;bundle-version="3.0.0",
+ org.eclipse.emf.emfatic.core;bundle-version="1.1.0"
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.emf.emfatic.compare.ecore
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/META-INF/MANIFEST.MF
@@ -12,7 +12,10 @@ Require-Bundle: org.eclipse.compare;bundle-version="3.0.0",
  org.eclipse.emf.compare.ide.ui;bundle-version="4.0.0",
  org.eclipse.emf.compare.rcp.ui;bundle-version="4.0.0",
  org.eclipse.emf.compare;bundle-version="3.0.0",
- org.eclipse.emf.emfatic.core;bundle-version="1.2.0"
+ org.eclipse.emf.emfatic.core;bundle-version="1.2.0",
+ org.eclipse.jface.text;bundle-version="3.0.0",
+ org.eclipse.emf.emfatic.ui,
+ org.eclipse.gymnast.runtime.ui
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.emf.emfatic.compare.ecore
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/META-INF/MANIFEST.MF
@@ -8,11 +8,11 @@ Require-Bundle: org.eclipse.compare;bundle-version="3.0.0",
  org.eclipse.swt;bundle-version="3.0.0",
  org.eclipse.jface;bundle-version="3.0.0",
  org.eclipse.core.runtime;bundle-version="3.0.0",
- org.eclipse.text,
- org.eclipse.emf.compare.ide.ui;bundle-version="4.4.3",
- org.eclipse.emf.compare.rcp.ui;bundle-version="4.4.2",
+ org.eclipse.text;bundle-version="3.0.0",
+ org.eclipse.emf.compare.ide.ui;bundle-version="4.0.0",
+ org.eclipse.emf.compare.rcp.ui;bundle-version="4.0.0",
  org.eclipse.emf.compare;bundle-version="3.0.0",
- org.eclipse.emf.emfatic.core;bundle-version="1.1.0"
+ org.eclipse.emf.emfatic.core;bundle-version="1.2.0"
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.emf.emfatic.compare.ecore
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Ecore comparison support for Emfatic
+Bundle-SymbolicName: org.eclipse.emf.emfatic.compare.ecore;singleton:=true
+Bundle-Version: 1.2.0.qualifier
+Export-Package: org.eclipse.emf.emfatic.compare.ecore
+Require-Bundle: org.eclipse.compare;bundle-version="3.0.0",
+ org.eclipse.swt;bundle-version="3.0.0",
+ org.eclipse.jface;bundle-version="3.0.0",
+ org.eclipse.core.runtime;bundle-version="3.0.0",
+ org.eclipse.text
+Bundle-Vendor: Eclipse.org
+Automatic-Module-Name: org.eclipse.emf.emfatic.compare.ecore
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/build.properties
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/plugin.xml
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/plugin.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.compare.contentMergeViewers">
+      <viewer
+            class="org.eclipse.emf.emfatic.compare.ecore.EcoreToEmfaticViewerCreator"
+            extensions="org.eclipse.emf.compare.rcp.ui.ematch"
+            id="org.eclipse.emf.emfatic.compare.ecore.viewer"
+            label="Emfatic Compare">
+      </viewer>
+   </extension>
+
+</plugin>

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewer.java
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewer.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.compare.ide.ui.internal.contentmergeviewer.accessor.Acces
 import org.eclipse.emf.compare.rcp.ui.internal.contentmergeviewer.accessor.impl.MatchAccessor;
 import org.eclipse.emf.compare.rcp.ui.mergeviewer.item.IMergeViewerItem;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.emfatic.core.generator.emfatic.Writer;
 import org.eclipse.jface.text.AbstractDocument;
@@ -117,12 +118,24 @@ public class EcoreToEmfaticViewer extends TextMergeViewer {
 
 		@Override
 		public ITypedElement getLeft() {
-			return getDocument(left.eResource());
+			if (left != null) {
+				return getDocument(left.eResource());
+			} else {
+				return null;
+			}
 		}
 
 		private ITypedElement getDocument(Resource eResource) {
-			Writer w = new Writer();
-			String text = w.write(eResource);
+			String text = null;
+			for (EObject root : eResource.getContents()) {
+				if (!(root instanceof EPackage)) {
+					text = "Not an Ecore metamodel - cannot turn into Emfatic source";
+				}
+			}
+			if (text == null) {
+				Writer w = new Writer();
+				text = w.write(eResource);
+			}
 
 			DummyDocument leftDoc = new DummyDocument();
 			leftDoc.set(text);
@@ -131,7 +144,11 @@ public class EcoreToEmfaticViewer extends TextMergeViewer {
 
 		@Override
 		public ITypedElement getRight() {
-			return getDocument(right.eResource());
+			if (right != null) {
+				return getDocument(right.eResource());
+			} else {
+				return null;
+			}
 		}
 
 		@Override

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewer.java
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewer.java
@@ -73,7 +73,7 @@ public class EcoreToEmfaticViewer extends TextMergeViewer {
 
 		@Override
 		public Image getImage() {
-			// TODO Auto-generated method stub
+			// no image
 			return null;
 		}
 

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewer.java
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewer.java
@@ -21,9 +21,14 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.emfatic.core.generator.emfatic.Writer;
+import org.eclipse.emf.emfatic.ui.editor.EmfaticEditor;
+import org.eclipse.emf.emfatic.ui.editor.EmfaticSourceViewerConfiguration;
 import org.eclipse.jface.text.AbstractDocument;
 import org.eclipse.jface.text.DefaultLineTracker;
 import org.eclipse.jface.text.ITextStore;
+import org.eclipse.jface.text.TextViewer;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.SourceViewerConfiguration;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 
@@ -180,6 +185,16 @@ public class EcoreToEmfaticViewer extends TextMergeViewer {
 	@Override
 	public String getTitle() {
 		return "Emfatic Compare";
+	}
+
+	@Override
+	protected void configureTextViewer(TextViewer textViewer) {
+		super.configureTextViewer(textViewer);
+
+		if (textViewer instanceof ISourceViewer) {
+			SourceViewerConfiguration configuration = new EmfaticSourceViewerConfiguration(new EmfaticEditor());
+			configuration.getPresentationReconciler((ISourceViewer) textViewer).install(textViewer);
+		}
 	}
 
 	protected EObject getEObject(Object inputSide) {

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewer.java
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewer.java
@@ -1,0 +1,153 @@
+/*********************************************************************
+ * Copyright (c) 2024 The University of York.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.emf.emfatic.compare.ecore;
+
+import org.eclipse.compare.CompareConfiguration;
+import org.eclipse.compare.ITypedElement;
+import org.eclipse.compare.contentmergeviewer.TextMergeViewer;
+import org.eclipse.compare.structuremergeviewer.ICompareInput;
+import org.eclipse.compare.structuremergeviewer.ICompareInputChangeListener;
+import org.eclipse.jface.text.AbstractDocument;
+import org.eclipse.jface.text.DefaultLineTracker;
+import org.eclipse.jface.text.ITextStore;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
+
+public class EcoreToEmfaticViewer extends TextMergeViewer {
+
+	protected static class DummyDocument extends AbstractDocument implements ITypedElement {
+
+		protected static class StringStore implements ITextStore {
+			private String store = "";
+
+			@Override
+			public char get(int offset) {
+				return store.charAt(offset);
+			}
+
+			@Override
+			public String get(int offset, int length) {
+				return store.substring(offset, offset + length);
+			}
+
+			@Override
+			public int getLength() {
+				return store.length();
+			}
+
+			@Override
+			public void replace(int offset, int length, String text) {
+				// not allowed
+			}
+
+			@Override
+			public void set(String text) {
+				this.store = text;
+			}
+		}
+
+		public DummyDocument() {
+			setTextStore(new StringStore());
+			setLineTracker(new DefaultLineTracker());
+		}
+
+		@Override
+		public String getName() {
+			return "Name";
+		}
+
+		@Override
+		public Image getImage() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public String getType() {
+			return "dummy";
+		}
+	}
+
+	protected static class EmfaticCompareInput implements ICompareInput {
+		private final ICompareInput originalInput;
+
+		protected EmfaticCompareInput(ICompareInput originalInput) {
+			this.originalInput = originalInput;
+		}
+
+		@Override
+		public String getName() {
+			return originalInput.getName();
+		}
+
+		@Override
+		public Image getImage() {
+			return originalInput.getImage();
+		}
+
+		@Override
+		public int getKind() {
+			return originalInput.getKind();
+		}
+
+		@Override
+		public ITypedElement getAncestor() {
+			// TODO no three way support for now
+			return null;
+		}
+
+		@Override
+		public ITypedElement getLeft() {
+			// TODO compute Emfatic text from the left element
+			DummyDocument leftDoc = new DummyDocument();
+			leftDoc.set("common\nleft");
+			return leftDoc;
+		}
+
+		@Override
+		public ITypedElement getRight() {
+			// TODO compute Emfatic text from the right element
+			DummyDocument rightDoc = new DummyDocument();
+			rightDoc.set("common\nright");
+			return rightDoc;
+		}
+
+		@Override
+		public void addCompareInputChangeListener(ICompareInputChangeListener listener) {
+			// nothing to do
+		}
+
+		@Override
+		public void removeCompareInputChangeListener(ICompareInputChangeListener listener) {
+			// nothing to do
+		}
+
+		@Override
+		public void copy(boolean leftToRight) {
+			// do nothing
+		}
+	}
+
+	public EcoreToEmfaticViewer(Composite parent, CompareConfiguration configuration) {
+		super(parent, configuration);
+	}
+
+	@Override
+	public void setInput(Object input) {
+		ICompareInput originalInput = (ICompareInput) input;
+		super.setInput(new EmfaticCompareInput(originalInput));
+	}
+
+	@Override
+	public String getTitle() {
+		return "Emfatic Compare";
+	}
+	
+}

--- a/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewerCreator.java
+++ b/bundles/org.eclipse.emf.emfatic.compare.ecore/src/org/eclipse/emf/emfatic/compare/ecore/EcoreToEmfaticViewerCreator.java
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (c) 2024 The University of York.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.emf.emfatic.compare.ecore;
+
+import org.eclipse.compare.CompareConfiguration;
+import org.eclipse.compare.IViewerCreator;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.widgets.Composite;
+
+public class EcoreToEmfaticViewerCreator implements IViewerCreator {
+
+	@Override
+	public Viewer createViewer(Composite parent, CompareConfiguration config) {
+		return new EcoreToEmfaticViewer(parent, config);
+	}
+
+}

--- a/bundles/org.eclipse.emf.emfatic.core/src/org/eclipse/emf/emfatic/core/generator/emfatic/EmfaticGenerator.java
+++ b/bundles/org.eclipse.emf.emfatic.core/src/org/eclipse/emf/emfatic/core/generator/emfatic/EmfaticGenerator.java
@@ -44,7 +44,7 @@ public class EmfaticGenerator {
             Resource ecoreResource = getResource(_resourceSet, ecoreFilePath);
             String emfaticFilePath = getEmfaticFilePath(ecoreFile);
             Writer writer = new Writer();
-            String emfaticText = writer.write(ecoreResource, monitor, ecoreFile);
+            String emfaticText = writer.write(ecoreResource);
             writeEmfaticFile(emfaticFilePath, emfaticText.toString());
         }
         catch(Exception ex)

--- a/bundles/org.eclipse.emf.emfatic.core/src/org/eclipse/emf/emfatic/core/generator/emfatic/Writer.java
+++ b/bundles/org.eclipse.emf.emfatic.core/src/org/eclipse/emf/emfatic/core/generator/emfatic/Writer.java
@@ -677,6 +677,20 @@ public class Writer {
 
 	private Pattern _escapeQuotes;
 
+	public static String stringify(EPackage ePackage) {
+		Writer w = new Writer();
+
+		EPackage mainPackage = getRootEPackage(ePackage);
+		if (mainPackage != null) {
+			w._processingEcore = w.initProcessingEcore(mainPackage);
+		}
+		w._annotationMap = new EmfaticAnnotationMap();
+		w._buf = new StringBuffer();
+
+		w.writeSubPackage(ePackage, 0);
+		return w._buf.toString();
+	}
+
 	public static String stringify(EObject ecoreDecl) {
 		Writer w = new Writer();
 		EPackage mainPackage = getRootEPackage(ecoreDecl);

--- a/bundles/org.eclipse.emf.emfatic.core/src/org/eclipse/emf/emfatic/core/generator/emfatic/Writer.java
+++ b/bundles/org.eclipse.emf.emfatic.core/src/org/eclipse/emf/emfatic/core/generator/emfatic/Writer.java
@@ -51,11 +51,15 @@ import org.eclipse.emf.emfatic.core.util.EmfaticKeywords;
 
 public class Writer {
 
-	public Writer() {
+	/**
+	 * @deprecated Use {@link #write(Resource)} instead.
+	 */
+	@Deprecated
+	public String write(Resource ecoreResource, IProgressMonitor monitor, IFile ecoreFile) {
+		return write(ecoreResource);
 	}
 
-	public String write(Resource ecoreResource, IProgressMonitor monitor,
-			IFile ecoreFile) {
+	public String write(Resource ecoreResource) {
 		_buf = new StringBuffer();
 
 		if (ecoreResource.getContents().size() > 1) {

--- a/features/org.eclipse.emf.emfatic-feature/feature.xml
+++ b/features/org.eclipse.emf.emfatic-feature/feature.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="org.eclipse.emf.emfatic" label="Emfatic" version="1.2.0.qualifier" provider-name="Eclipse.org">
+<feature
+      id="org.eclipse.emf.emfatic"
+      label="Emfatic"
+      version="1.2.0.qualifier"
+      provider-name="Eclipse.org">
 
    <description url="http://www.eclipse.org/modeling/emft/emfatic">
       Emfatic is a text editor supporting navigation, editing,  and
@@ -322,37 +326,26 @@ version(s), and exceptions or additional permissions here}.&quot;
 
    <plugin
          id="org.eclipse.emf.emfatic.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.emfatic.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.emfatic.doc.user"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.gymnast.runtime.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.gymnast.runtime.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.emf.emfatic.compare.ecore"
+         version="0.0.0"/>
 
 </feature>


### PR DESCRIPTION
This pull request adds an "Emfatic Compare" method to the model comparison UI provided by EMF Compare, which looks like this:

![image](https://github.com/user-attachments/assets/138ec6ee-f0fd-4b6a-b7f9-b0a1799fcbdf)

The method works by turning both sides to Emfatic, and comparing the text. It supports the same syntax highlighting as in the regular Emfatic editor, and it allows for comparing the entire .ecore (by selecting the root element), or a specific subpackage, EClass, or EStructuralFeature.